### PR TITLE
Automatic scroll up fixed

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -23,6 +23,18 @@ export default function Layout() {
   const [activeSection, setActiveSection] = useState("/");
   const location = useLocation();
 
+  
+  //This useEffect handles scrolling to the top on navigation
+  useEffect(() => {
+    //Scroll to the top instantly when the pathname changes
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "instant", // Use "smooth" for a smooth scroll animation
+    });
+  }, [location.pathname]); // This effect runs every time the pathname changes
+
+
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 20);


### PR DESCRIPTION
Worked on the automatic scroll up. Now page scrolls up irrespective of where a client was before switching tabs